### PR TITLE
reduce wi24 image size by using `mamba clean` and other housekeeping

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,14 +8,17 @@ name: Docker
 
 on:
   push:
-    branches: [ "master", "*" ]
+    branches: [ "master" ]
+    paths-ignore:
+      - 'README.md'
+      - '*.yaml'
+  pull_request:
+    branches: [ "*" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
     paths-ignore:
       - 'README.md'
       - '*.yaml'
-  pull_request:
-    branches: [ "master" ]
   
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,29 +22,37 @@ RUN apt-get update && \
                     tree \
                     -y
 
-RUN mamba install -c conda-forge bash_kernel nb_conda_kernels
+# RUN conda config --set channel_priority strict && \
+RUN mamba install -y -n base -c conda-forge --override-channels bash_kernel nb_conda_kernels
 
 # create scanpy_2021 conda environment with required python packages
 COPY scanpy_2021.yaml /tmp
-RUN mamba env create --file /tmp/scanpy_2021.yaml
+RUN mamba env create --file /tmp/scanpy_2021.yaml && \
+    mamba clean -afy
 
 COPY variant_calling.yml /tmp
-RUN mamba env create --file /tmp/variant_calling.yml
+RUN mamba env create --file /tmp/variant_calling.yml && \
+    mamba clean -afy
 
 COPY programming-R.yaml /tmp
-RUN mamba env create --file /tmp/programming-R.yaml
+RUN mamba env create --file /tmp/programming-R.yaml && \
+    mamba clean -afy
 
 COPY chipseq.yml /tmp
-RUN mamba env create --file /tmp/chipseq.yml
+RUN mamba env create --file /tmp/chipseq.yml && \
+    mamba clean -afy
 
 COPY gwas.yml /tmp
-RUN mamba env create --file /tmp/gwas.yml
+RUN mamba env create --file /tmp/gwas.yml && \
+    mamba clean -afy
 
 COPY stats.yml /tmp
-RUN mamba env create --file /tmp/stats.yml
+RUN mamba env create --file /tmp/stats.yml && \
+    mamba clean -afy
 
 COPY spatial-tx.yml /tmp
-RUN mamba env create --file /tmp/spatial-tx.yml
+RUN mamba env create --file /tmp/spatial-tx.yml && \
+    mamba clean -afy
 
 RUN yes | unminimize || echo "done"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN sed -i 's:^path-exclude=/usr/share/man:#path-exclude=/usr/share/man:' \
         /etc/dpkg/dpkg.cfg.d/excludes
 
 # install linux packages
-RUN apt-get update && \
-    apt-get install tk-dev \
+RUN apt-get update && apt-get install -y \
+                    tk-dev \
                     tcl-dev \
                     cmake \
                     wget \
@@ -20,7 +20,7 @@ RUN apt-get update && \
                     man-db \
                     manpages-posix \
                     tree \
-                    -y
+                    && rm -rf /var/lib/apt/lists/*
 
 RUN conda config --set channel_priority strict && \
     mamba install -y -n base -c conda-forge --override-channels bash_kernel nb_conda_kernels

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,19 @@ RUN sed -i 's:^path-exclude=/usr/share/man:#path-exclude=/usr/share/man:' \
 
 # install linux packages
 RUN apt-get update && apt-get install -y \
-    tk-dev=8.6.9+1 /
-    tcl-dev=8.6.9+1 /
-    cmake=3.16.3-1ubuntu1.20.04.1 /
-    wget=1.20.3-1ubuntu2 /
-    default-jdk=2:1.11-72 /
-    libbz2-dev=1.0.8-2 /
-    apt-utils=2.0.9 /
-    gdebi-core=0.9.5.7+nmu3 /
-    dpkg-sig=0.13.1+nmu4 /
-    manpages=5.05-1 /
-    man-db=2.9.1-1 /
-    manpages-posix=2013a-2 /
-    tree=1.8.0-1 /
+    tk-dev=8.6.9+1 \
+    tcl-dev=8.6.9+1 \
+    cmake=3.16.3-1ubuntu1.20.04.1 \
+    wget=1.20.3-1ubuntu2 \
+    default-jdk=2:1.11-72 \
+    libbz2-dev=1.0.8-2 \
+    apt-utils=2.0.9 \
+    gdebi-core=0.9.5.7+nmu3 \
+    dpkg-sig=0.13.1+nmu4 \
+    manpages=5.05-1 \
+    man-db=2.9.1-1 \
+    manpages-posix=2013a-2 \
+    tree=1.8.0-1 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN conda config --set channel_priority strict && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,24 @@ FROM ucsdets/datahub-base-notebook:2023.1-stable
 USER root
 
 RUN sed -i 's:^path-exclude=/usr/share/man:#path-exclude=/usr/share/man:' \
-        /etc/dpkg/dpkg.cfg.d/excludes
+    /etc/dpkg/dpkg.cfg.d/excludes
 
 # install linux packages
 RUN apt-get update && apt-get install -y \
-                    tk-dev \
-                    tcl-dev \
-                    cmake \
-                    wget \
-                    default-jdk \
-                    libbz2-dev \
-                    apt-utils \
-                    gdebi-core \
-                    dpkg-sig \
-                    man \
-                    man-db \
-                    manpages-posix \
-                    tree \
-                    && rm -rf /var/lib/apt/lists/*
+    tk-dev=8.6.9+1 /
+    tcl-dev=8.6.9+1 /
+    cmake=3.16.3-1ubuntu1.20.04.1 /
+    wget=1.20.3-1ubuntu2 /
+    default-jdk=2:1.11-72 /
+    libbz2-dev=1.0.8-2 /
+    apt-utils=2.0.9 /
+    gdebi-core=0.9.5.7+nmu3 /
+    dpkg-sig=0.13.1+nmu4 /
+    manpages=5.05-1 /
+    man-db=2.9.1-1 /
+    manpages-posix=2013a-2 /
+    tree=1.8.0-1 /
+    && rm -rf /var/lib/apt/lists/*
 
 RUN conda config --set channel_priority strict && \
     mamba install -y -n base -c conda-forge --override-channels bash_kernel nb_conda_kernels

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,6 @@ RUN apt-get update && apt-get install -y \
 RUN conda config --set channel_priority strict && \
     mamba install -y -n base -c conda-forge --override-channels bash_kernel nb_conda_kernels
 
-# create scanpy_2021 conda environment with required python packages
-COPY scanpy_2021.yaml /tmp
-RUN mamba env create --file /tmp/scanpy_2021.yaml && \
-    mamba clean -afy
-
-COPY variant_calling.yml /tmp
-RUN mamba env create --file /tmp/variant_calling.yml && \
-    mamba clean -afy
-
 COPY programming-R.yaml /tmp
 RUN mamba env create --file /tmp/programming-R.yaml && \
     mamba clean -afy
@@ -50,13 +41,21 @@ COPY stats.yml /tmp
 RUN mamba env create --file /tmp/stats.yml && \
     mamba clean -afy
 
-COPY spatial-tx.yml /tmp
-RUN mamba env create --file /tmp/spatial-tx.yml && \
-    mamba clean -afy
+# COPY scrna-seq.yaml /tmp
+# RUN mamba env create --file /tmp/scrna-seq.yaml && \
+#     mamba clean -afy
 
 COPY imgproc.yml /tmp
 RUN mamba env create --file /tmp/imgproc.yml && \
     mamba clean -afy
+
+COPY spatial-tx.yml /tmp
+RUN mamba env create --file /tmp/spatial-tx.yml && \
+    mamba clean -afy
+
+# COPY variant_calling.yml /tmp
+# RUN mamba env create --file /tmp/variant_calling.yml && \
+#     mamba clean -afy
 
 RUN yes | unminimize || echo "done"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && \
                     tree \
                     -y
 
-# RUN conda config --set channel_priority strict && \
-RUN mamba install -y -n base -c conda-forge --override-channels bash_kernel nb_conda_kernels
+RUN conda config --set channel_priority strict && \
+    mamba install -y -n base -c conda-forge --override-channels bash_kernel nb_conda_kernels
 
 # create scanpy_2021 conda environment with required python packages
 COPY scanpy_2021.yaml /tmp


### PR DESCRIPTION
this PR does some housekeeping

1. ensure bash_kernel and nb_conda_kernels are installed from conda-forge, **not** defaults
2. use `mamba clean` to reduce our image size quite a bit
3. update push and pull_request triggers so that builds only happen on push to the master branch or on the creation of pull requests
4. set strict channel priority as a config option
5. do not run conda install as a root user like [here](https://github.com/ucsd-ets/BNFO000/blob/cdde65b9882ec7fbff5b4124946f67a59151e035/Dockerfile#L9)? (still TODO)
    could this be why we have a `USER $NB_USER` at the end of our Dockerfile? so maybe we just need to move this up
    see also [these docs about the parent image](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/common.html#conda-environments)
    it's not clear why our Dockerfile currently uses the root user. I'd actually like to ask DataHub about this...
6. remove some packages and pin versions in the apt-get section so that they don't need to be rebuilt (see [the docker docs for this](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run))
7. remove the `scanpy` and `variant_calling` environments to save up some space